### PR TITLE
[Feat] 게시글 검색 동적 쿼리 기능 수정 및 게시글+후기 검색 기능 구현 (진행중)

### DIFF
--- a/backend/src/main/java/com/example/bootshelf/boardsvc/board/controller/BoardController.java
+++ b/backend/src/main/java/com/example/bootshelf/boardsvc/board/controller/BoardController.java
@@ -143,7 +143,10 @@ public class BoardController {
         return ResponseEntity.ok().body(boardService.searchBoardListByQuery(query, searchType, pageable));
     }
 
-    /*
+    /**
+     *  게시판 + 후기 검색 api (v2)
+     *  -> 페이지네이션 잘 안됨
+     */
     @Operation(summary = "Board+Review 게시글 검색어로 조회 v2",
             description = "게시판+후기 데이터를 검색어(키워드)로 조회하는 API입니다.")
     @ApiResponses({
@@ -157,7 +160,6 @@ public class BoardController {
     ){
         return ResponseEntity.ok().body(boardService.searchResultListByQueryV2(query, searchType, pageable));
     }
-    */
 
 
     @Operation(summary = "Board 게시글 수정 기능",

--- a/backend/src/main/java/com/example/bootshelf/boardsvc/board/repository/querydsl/BoardRepositoryCustom.java
+++ b/backend/src/main/java/com/example/bootshelf/boardsvc/board/repository/querydsl/BoardRepositoryCustom.java
@@ -19,4 +19,6 @@ public interface BoardRepositoryCustom {
     Page<Board> findBoardListByTag(Pageable pageable, Integer TagIdx, Integer sortIdx);
 
     Page<Board> searchBoardListByQuery(Pageable pageable, String keyword, Integer searchType);
+
+    Page<Board> searchBoardListByQueryV2(Pageable pageable, String query, Integer searchType);
 }

--- a/backend/src/main/java/com/example/bootshelf/boardsvc/board/repository/querydsl/BoardRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/example/bootshelf/boardsvc/board/repository/querydsl/BoardRepositoryCustomImpl.java
@@ -17,7 +17,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class BoardRepositoryCustomImpl extends QuerydslRepositorySupport implements BoardRepositoryCustom {
-    public BoardRepositoryCustomImpl() { super(Board.class); }
+    public BoardRepositoryCustomImpl() {
+        super(Board.class);
+    }
 
     @Override
     public Page<Board> findMyBoardList(Integer userIdx, Pageable pageable, Integer sortIdx) {
@@ -54,7 +56,7 @@ public class BoardRepositoryCustomImpl extends QuerydslRepositorySupport impleme
     }
 
     @Override
-    public Page<Board> findBoardListByCategory (Pageable pageable, Integer categoryIdx, Integer sortIdx) {
+    public Page<Board> findBoardListByCategory(Pageable pageable, Integer categoryIdx, Integer sortIdx) {
         QBoard board = new QBoard("board");
 
         OrderSpecifier[] orderSpecifiers = createOrderSpecifier(sortIdx, board);
@@ -71,7 +73,7 @@ public class BoardRepositoryCustomImpl extends QuerydslRepositorySupport impleme
     }
 
     @Override
-    public Page<Board> findBoardListByTag (Pageable pageable, Integer tagIdx, Integer sortIdx) {
+    public Page<Board> findBoardListByTag(Pageable pageable, Integer tagIdx, Integer sortIdx) {
         QBoard board = new QBoard("board");
         QBoardTag boardTag = new QBoardTag("boardTag");
 
@@ -89,7 +91,7 @@ public class BoardRepositoryCustomImpl extends QuerydslRepositorySupport impleme
         return new PageImpl<>(result, pageable, result.size());
     }
 
-    private OrderSpecifier[] createOrderSpecifier(Integer sortIdx, QBoard board)  {
+    private OrderSpecifier[] createOrderSpecifier(Integer sortIdx, QBoard board) {
         List<OrderSpecifier> orderSpecifiers = new ArrayList<>();
 
         switch (sortIdx) {
@@ -143,6 +145,44 @@ public class BoardRepositoryCustomImpl extends QuerydslRepositorySupport impleme
     }
 
     private BooleanExpression contentContains(String query) {
+        if (query == null || query.trim().isEmpty()) return null;
+        return QBoard.board.boardContent.containsIgnoreCase(query);
+    }
+
+
+    /**
+     *  게시판 (+ 후기) 검색 api (v2)
+     *  -> 페이지네이션 잘 안됨
+     */
+    @Override
+    public Page<Board> searchBoardListByQueryV2(Pageable pageable, String query, Integer searchType) {
+        QBoard qBoard = QBoard.board;
+
+        // 검색 조건
+        BooleanExpression searchCondition = searchType == 1 ? titleContainsV2(query)
+                : titleContainsV2(query).or(contentContainsV2(query)); // Ensure correct method names are used
+
+        // 조회 쿼리 생성 및 페이징 처리
+        JPQLQuery<Board> querySQL = from(qBoard)
+                .leftJoin(qBoard.user).fetchJoin()
+                .leftJoin(qBoard.boardCategory).fetchJoin()
+                .where(searchCondition)
+                .orderBy(qBoard.createdAt.desc());
+
+        // pagination 적용
+        JPQLQuery<Board> pageableQuery = getQuerydsl().applyPagination(pageable, querySQL);
+        List<Board> boardList = pageableQuery.fetch();
+        long count = pageableQuery.fetchCount(); // Fetch the count of all matching records
+
+        return new PageImpl<>(boardList, pageable, count); // Return a Page<Board> instead of List<Board>
+    }
+
+    private BooleanExpression titleContainsV2(String query) {
+        if (query == null || query.trim().isEmpty()) return null;
+        return QBoard.board.boardTitle.containsIgnoreCase(query);
+    }
+
+    private BooleanExpression contentContainsV2(String query) {
         if (query == null || query.trim().isEmpty()) return null;
         return QBoard.board.boardContent.containsIgnoreCase(query);
     }

--- a/backend/src/main/java/com/example/bootshelf/reviewsvc/review/repository/querydsl/ReviewRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/example/bootshelf/reviewsvc/review/repository/querydsl/ReviewRepositoryCustomImpl.java
@@ -166,6 +166,11 @@ public class ReviewRepositoryCustomImpl extends QuerydslRepositorySupport implem
         return QReview.review.reviewContent.containsIgnoreCase(query);
     }
 
+
+    /**
+     *  (게시판 +) 후기 검색 api (v2)
+     *  -> 페이지네이션 잘 안됨
+     */
     @Override
     public Page<Review> searchReviewListByQueryV2(Pageable pageable, String query, Integer searchType) {
         QReview qReview = QReview.review;

--- a/frontend/src/stores/useUserStore.js
+++ b/frontend/src/stores/useUserStore.js
@@ -42,6 +42,19 @@ export const useUserStore = defineStore("user", {
       this.decodedToken = decodedToken;
     },
 
+    decodeToken() {
+      const storedToken = localStorage.getItem("token");
+      if (storedToken) {
+        const decoded = VueJwtDecode.decode(storedToken);
+        if (decoded.exp < Date.now() / 1000) {
+          this.logout(); 
+        } else {
+          this.decodedToken = decoded;
+          this.isAuthenticated = true;
+        }
+      }
+    },
+
     logout() {
       window.localStorage.removeItem("token");
       this.isAuthenticated = false;


### PR DESCRIPTION
[Feat] 게시글 검색 동적 쿼리 기능 수정 및 게시글+후기 검색 기능 구현 (진행중)

- 문제
  - 페이지네이션 제대로 되지 않아서
    예상되는 결과 데이터가 매우 많은데
    board에서 20개
    review에서 20개
    총 2개 페이지 40개의 데이터만 조회되고 있다.