### PR TITLE
[Fix] 백엔드 후기글 댓글 추천,취소 기능 수정 (#49, #50)

### DIFF
--- a/backend/src/main/java/com/example/bootshelf/reviewsvc/reviewcomment/model/response/GetListReviewCommentRes.java
+++ b/backend/src/main/java/com/example/bootshelf/reviewsvc/reviewcomment/model/response/GetListReviewCommentRes.java
@@ -13,6 +13,7 @@ public class GetListReviewCommentRes {
     private Integer idx;
     private Integer reviewIdx;
     private Integer userIdx;
+    private String userImg;
     private String userNickName;
     private String reviewCommnetContent;
     private String createAt;

--- a/backend/src/main/java/com/example/bootshelf/reviewsvc/reviewcomment/service/ReviewCommentService.java
+++ b/backend/src/main/java/com/example/bootshelf/reviewsvc/reviewcomment/service/ReviewCommentService.java
@@ -112,6 +112,7 @@ public class ReviewCommentService {
                 .reviewIdx(reviewComment.getReview().getIdx())
                 .userIdx(reviewComment.getUser().getIdx())
                 .userNickName(reviewComment.getUser().getNickName())
+                .userImg(reviewComment.getUser().getProfileImage())
                 .reviewCommnetContent(reviewComment.getReviewCommentContent())
                 .createAt(reviewComment.getCreatedAt())
                 .updateAt(reviewComment.getUpdatedAt())

--- a/backend/src/main/java/com/example/bootshelf/reviewsvc/reviewcommentup/controller/ReviewCommentUpController.java
+++ b/backend/src/main/java/com/example/bootshelf/reviewsvc/reviewcommentup/controller/ReviewCommentUpController.java
@@ -79,11 +79,11 @@ public class ReviewCommentUpController {
             @ApiResponse(responseCode = "200", description = "성공"),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류")
     })
-    @PatchMapping("/delete/{reviewCommentUpIdx}")
+    @PatchMapping("/delete/{reviewCommentIdx}")
     public ResponseEntity<BaseRes> deleteReviewCommentUp(
             @AuthenticationPrincipal User user,
-            @PathVariable Integer reviewCommentUpIdx
+            @PathVariable Integer reviewCommentIdx
     ) {
-        return ResponseEntity.ok().body(reviewCommentUpService.deleteReviewCommentUp(user, reviewCommentUpIdx));
+        return ResponseEntity.ok().body(reviewCommentUpService.deleteReviewCommentUp(user, reviewCommentIdx));
     }
 }


### PR DESCRIPTION
- 테스트 하다보니 본인 댓글에만 추천을 누를 수 있게 되어있어 수정할 예정입니다...
- reviewIdx로 reviewCommentUp을 전체 조회하여 해당 게시글의 댓글의 추천 상태를 확인하는 코드를 추가할 예정입니다..