### PR TITLE
[Fix] 프론트엔드 관리자 태그 수정 페이지 주석 처리

### DIFF
--- a/frontend/src/components/AdminTagListComponent.vue
+++ b/frontend/src/components/AdminTagListComponent.vue
@@ -1,18 +1,17 @@
 <template>
   <td>
-    <span class="fw-medium">{{ tags.idx }}</span>
+    <span class="fw-medium">{{ tag.idx }}</span>
   </td>
-  <td>{{ tags.tagName }}</td>
+  <td>{{ tag.tagName }}</td>
   <td>
     <div class="dropdown" @click.prevent="toggleUserMenu($event)">
       <button type="button" class="btn p-0 dropdown-toggle hide-arrow" data-bs-toggle="dropdown">
         <i class="bx bx-dots-vertical-rounded"></i>
       </button>
       <div class="dropdown-menu" v-show="userMenuVisible">
-        <router-link
-          :to="{ name: 'AdminTagUpdate', params: { categoryIdx: tag.idx, categoryName: tag.name } }">
+        <!-- <router-link :to="{ name: 'AdminTagUpdate', params: { categoryIdx: tag.idx, categoryName: tag.tagName } }"> -->
           <a class="dropdown-item"><i class="bx bx-edit-alt me-1"></i>수정</a>
-        </router-link>
+        <!-- </router-link> -->
         <a class="dropdown-item" @click="deleteTag"><i class="bx bx-trash me-1"></i> 삭제</a>
       </div>
     </div>
@@ -46,7 +45,7 @@ export default {
 
     const deleteTag = async () => {
       try {
-        await tagStore.deleteTag(props.tag.idx);
+        await tagStore.deleteTag(props.tags.idx);
         alert('태그가 삭제되었습니다.');
       } catch (error) {
         console.error('태그 삭제 에러:', error);

--- a/frontend/src/pages/AdminTagListPage.vue
+++ b/frontend/src/pages/AdminTagListPage.vue
@@ -24,8 +24,8 @@
                     </tr>
                   </thead>
                   <tbody class="table-border-bottom-0">
-                    <tr v-for="tags in tagStore.tagList" :key="tags.tagIdx">
-                      <AdminTagListComponent :tags="tags" />
+                    <tr v-for="tag in tagStore.tagList" :key="tag.tagIdx">
+                      <AdminTagListComponent :tag="tag" />
                     </tr>
                   </tbody>
                 </table>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -119,6 +119,12 @@ const routes = [
     component: AdminBoardCategoryUpdatePage,
     props: true
   },
+  // {
+  //   path: '/admin/tags/update/:categoryIdx',
+  //   name: 'AdminTagUpdate',
+  //   component: AdminTagUpdatePage,
+  //   props: true  
+  // },  
   { path: "/auth/signup", component: AuthSignupPage },
   { path: "/KakaoLogIn", component: KakaoLogIn },
   { path: "/signup", component: SignupPage },


### PR DESCRIPTION
- 에러로 인해 일단 관리자 태그 조회 페이지만 살려두고 수정 페이지는 잠정 보류